### PR TITLE
fix: deprecation warning with mixed return type in doc blocks

### DIFF
--- a/src/Core/Response/ResponseInterface.php
+++ b/src/Core/Response/ResponseInterface.php
@@ -12,9 +12,6 @@ interface ResponseInterface
      */
     public function getHeaders(): array;
     public function getRawBody(): string;
-    /**
-     * @return mixed
-     */
-    public function getBody(): mixed;
+    public function getBody();
     public function convert(ConverterInterface $converter);
 }

--- a/src/Core/Response/ResponseInterface.php
+++ b/src/Core/Response/ResponseInterface.php
@@ -15,6 +15,6 @@ interface ResponseInterface
     /**
      * @return mixed
      */
-    public function getBody();
+    public function getBody(): mixed;
     public function convert(ConverterInterface $converter);
 }


### PR DESCRIPTION
Remaining indirect deprecation notices (1)

  1x: Method "CoreInterfaces\Core\Response\ResponseInterface::getBody()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Unirest\Response" now to avoid errors or add an explicit @return annotation to suppress this message.

## What
When I run my phpunitest I have this warning

## Why
I would like to get rid of the warning :)

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)