### PR TITLE
feat: validator for non null and non empty parameter

### DIFF
--- a/src/Core/Request/NonEmptyParamInterface.php
+++ b/src/Core/Request/NonEmptyParamInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace CoreInterfaces\Core\Request;
+
+interface NonEmptyParamInterface extends ParamInterface
+{
+    public function requiredNonEmpty();
+}

--- a/src/Core/Request/ParamInterface.php
+++ b/src/Core/Request/ParamInterface.php
@@ -12,7 +12,6 @@ interface ParamInterface
      */
     public function extract(string $key, $defaultValue = null);
     public function required();
-    public function requiredNonEmpty();
     /**
      * To perform validation and serialization for un unusual types.
      */

--- a/src/Core/Request/ParamInterface.php
+++ b/src/Core/Request/ParamInterface.php
@@ -12,6 +12,7 @@ interface ParamInterface
      */
     public function extract(string $key, $defaultValue = null);
     public function required();
+    public function requiredNonEmpty();
     /**
      * To perform validation and serialization for un unusual types.
      */


### PR DESCRIPTION
## What
This PR adds a new validator function in ParamInterface to check if a paramerter's value is non null or non empty

## Why
We need to fail the validation if any parameter value is set to an empty string, for some cases

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
N/A

## Breaking change
N/A

## Testing
This is tested with the implementation of https://github.com/apimatic/core-lib-php/issues/55

## Checklist
- [X] My code follows the coding conventions
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas