### PR TITLE
ci: add github action for SonarQube scan

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Tests
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+permissions:
+  contents: read
+
+jobs:
+  sonar-scan:
+    name: SonarQube Scan
+    runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.head_commit.message), 'skip ci')"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: SonarQube Scan
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        uses: SonarSource/sonarqube-scan-action@v5.2.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # APIMatic Core Library Interfaces
 [![version][packagist-version]][packagist-url]
-[![Maintainability](https://api.codeclimate.com/v1/badges/8c44cc226ce627f4efab/maintainability)](https://codeclimate.com/github/apimatic/core-interfaces-php/maintainability)
+[![Maintainability Rating][maintainability-badge]][maintainability-url]
+[![Vulnerabilities][vulnerabilities-badge]][vulnerabilities-url]
 [![Licence][license-badge]][license-url]
 
 ## Introduction
@@ -51,5 +52,9 @@ composer require "apimatic/core-interfaces"
 [packagist-url]: https://packagist.org/packages/apimatic/core-interfaces
 [packagist-version]: https://img.shields.io/packagist/v/apimatic/core-interfaces.svg?style=flat
 [packagist-downloads]: https://img.shields.io/packagist/dm/apimatic/core-interfaces.svg?style=flat
+[maintainability-badge]: https://sonarcloud.io/api/project_badges/measure?project=apimatic_core-interfaces-php&metric=sqale_rating
+[maintainability-url]: https://sonarcloud.io/summary/new_code?id=apimatic_core-interfaces-php
+[vulnerabilities-badge]: https://sonarcloud.io/api/project_badges/measure?project=apimatic_core-interfaces-php&metric=vulnerabilities
+[vulnerabilities-url]: https://sonarcloud.io/summary/new_code?id=apimatic_core-interfaces-php
 [license-badge]: https://img.shields.io/badge/license-MIT-blue
 [license-url]: LICENSE

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,7 @@
+sonar.projectKey=apimatic_core-interfaces-php
+sonar.projectName=PHP Core Library Interfaces
+sonar.organization=apimatic
+sonar.host.url=https://sonarcloud.io
+sonar.sourceEncoding=UTF-8
+
+sonar.sources=src


### PR DESCRIPTION
This PR adds SonarQube Scan to CI workflow. It also adds badges from SonarCloud in Readme.